### PR TITLE
Set version of database-anonymizer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/console": "^2.0.5|^3.0|^4.0",
         "symfony/framework-bundle": "^4.0",
         "symfony/doctrine-bridge": "^4.2",
-        "webnet-fr/database-anonymizer": "dev-master"
+        "webnet-fr/database-anonymizer": "^0.0.3"
     },
     "require-dev": {
         "doctrine/annotations": "^1.6",


### PR DESCRIPTION
dev-master makes it against stable stability requirements for composer, but version 0.0.3 is released and can be required to meet the stable stability requirement.